### PR TITLE
Testing Update angular-soundmanager2.js

### DIFF
--- a/dist/angular-soundmanager2.js
+++ b/dist/angular-soundmanager2.js
@@ -18,7 +18,7 @@
  * About this file
  * -------------------------------------------------------------------------------------
  * This is the fully-commented source version of the SoundManager 2 API,
- * recommended for use during development and testing.
+ * recommended for use during development and testing.a
  *
  * See soundmanager2-nodebug-jsmin.js for an optimized build (~11KB with gzip.)
  * http://schillmania.com/projects/soundmanager2/doc/getstarted/#basic-inclusion
@@ -6156,8 +6156,9 @@ angular.module('angularSoundManager', [])
                 $rootScope.$broadcast('player:playlist', playlist);
             },
             addTrack: function (track) {
-                //check if url is playable
-                if (soundManager.canPlayURL(track.url) !== true) {
+            	
+            	//check if track itself is valid and if its url is playable
+                if (typeof track == 'undefined' || soundManager.canPlayURL(track.url) !== true) {
                     console.log('invalid song url');
                     return null;
                 }
@@ -6252,6 +6253,10 @@ angular.module('angularSoundManager', [])
                 this.initPlayTrack(trackId);
             },
             nextTrack: function () {
+               if (this.getCurrentTrack() === null){
+                   console.log("Please click on Play before this action");
+                   return null;
+              }
                 var currentTrackKey = this.getIndexByValue(soundManager.soundIDs, this.getCurrentTrack());
                 var nextTrackKey = +currentTrackKey + 1;
                 var nextTrack = soundManager.soundIDs[nextTrackKey];
@@ -6271,6 +6276,10 @@ angular.module('angularSoundManager', [])
                 }
             },
             prevTrack: function () {
+        	if (this.getCurrentTrack() === null){
+                    console.log("Please click on Play before this action");
+        	    return null;
+                }
                 var currentTrackKey = this.getIndexByValue(soundManager.soundIDs, this.getCurrentTrack());
                 var prevTrackKey = +currentTrackKey - 1;
                 var prevTrack = soundManager.soundIDs[prevTrackKey];
@@ -6329,6 +6338,16 @@ angular.module('angularSoundManager', [])
                         changeVolume(volume);
                     }
                 }
+            }, 
+            adjustVolumeSlider: function (value) {
+                var changeVolume = function (volume) {
+                    for (var i = 0; i < soundManager.soundIDs.length; i++) {
+                        var mySound = soundManager.getSoundById(soundManager.soundIDs[i]);
+                        mySound.setVolume(volume);
+                    }
+                    $rootScope.$broadcast('music:volume', volume);
+                };
+                changeVolume(value);
             },
             clearPlaylist: function (callback) {
                 console.log('clear playlist');
@@ -6607,6 +6626,39 @@ angular.module('angularSoundManager', [])
                     });
                 });
 
+            }
+        };
+    }])
+        .directive('volumeBar', ['angularPlayer', function (angularPlayer) {
+        return {
+            restrict: "EA",
+            link: function (scope, element, attrs) {
+
+                 element.bind('click', function (event) {
+                    var getXOffset = function (event) {
+                      var x = 0, element = event.target;
+                      while (element && !isNaN(element.offsetLeft) && !isNaN(element.offsetTop)) {
+                        x += element.offsetLeft - element.scrollLeft;
+                        element = element.offsetParent;
+                      }
+                      return event.clientX - x;
+                    };
+
+                    var x = event.offsetX || getXOffset(event),
+                        width = element[0].clientWidth,
+                        duration = 100;
+
+                    var volume = (x / width) * duration;
+                    angularPlayer.adjustVolumeSlider(volume);
+                });
+
+
+                scope.volume = angularPlayer.getVolume();
+                scope.$on('music:volume', function (event, data) {
+                    scope.$apply(function () {
+                        scope.volume = data;
+                    });
+                });
             }
         };
     }])

--- a/dist/angular-soundmanager2.js
+++ b/dist/angular-soundmanager2.js
@@ -18,7 +18,7 @@
  * About this file
  * -------------------------------------------------------------------------------------
  * This is the fully-commented source version of the SoundManager 2 API,
- * recommended for use during development and testing.a
+ * recommended for use during development and testing.
  *
  * See soundmanager2-nodebug-jsmin.js for an optimized build (~11KB with gzip.)
  * http://schillmania.com/projects/soundmanager2/doc/getstarted/#basic-inclusion


### PR DESCRIPTION
line 6160: 
I had problems when trying to play a song that doesn't exist (streaming it from my machine and not it from a url).

line 6256 / 6279:
When starting the player, if the user click on next or previous song, the player crashes because there is no current track by then and we try to get the previous or next track key. This prevents not desired results if the user click on prev or next before playing the first song (loading it).

line 6342.
adjustVolumeSlider is a new factory function to allow having volume not only with buttons but with a slider. Note that in this case we can change the volume with a range of 1 by 1 and not 10 by 10.

line 6632:
volumeBar is a new directive inspired on the seekBar, in this case the duration is 100 (max volume), we get the location of the bar where the user clicked and then we send that to our function adjustVolumeSlider created above. Allowing now to use now this directive in our html and have a volume control type slider.

Example:
 <div class="barBase" volume-bar>
                    <div class="barLoad" ng-style="{width: ( volume + '%')}"></div>
</div>